### PR TITLE
Updating data_live_base_url to fix empty squawk codes

### DIFF
--- a/FlightRadar24/core.py
+++ b/FlightRadar24/core.py
@@ -5,7 +5,7 @@ class Core(object):
     # Base URLs.
     cdn_flightradar_base_url = "https://cdn.flightradar24.com"
     flightradar_base_url = "https://www.flightradar24.com"
-    data_live_base_url = "https://data-live.flightradar24.com"
+    data_live_base_url = "https://data-cloud.flightradar24.com"
 
     # Flights data URLs.
     real_time_flight_tracker_data_url = data_live_base_url + "/zones/fcgi/feed.js"


### PR DESCRIPTION
All squawk code from requested flights are empty on the response structure.
Flightradar requests a different URL than the one currently in use to access squawk codes.

`Core.data_live_base_url` was updated to reflect this change.

The response structure of the new request is the same of the current one, but with a non-empty squawk field.
